### PR TITLE
Run unit tests on push

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,60 @@
+---
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+# minimal permissions
+permissions:
+  contents: read
+
+env:
+  CI: true
+
+jobs:
+  linux_unit_tests:
+    name: Ruby version
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.7'
+          - '3.0'
+          - '3.2'
+          - '3.3'
+          - 'jruby-9.4.8.0'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout current PR
+        uses: actions/checkout@v4
+
+      - name: Rspec checks
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake spec_random
+
+  windows_unit_tests:
+    name: Windows tests with Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby:
+          - '2.7'
+          - '3.2'
+    runs-on: windows-2025
+    steps:
+      - name: Checkout current PR
+        uses: actions/checkout@v4
+
+      - name: Rspec checks
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake spec_random

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require "bundler/gem_tasks"
-require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+Dir.glob(File.join('tasks/**/*.rake')).each { |file| load file }
 
-task :default => :spec
+task default: :spec

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+begin
+  require 'rspec/core/rake_task'
+
+  desc 'Run rspec test in sequential order'
+  RSpec::Core::RakeTask.new(:spec)
+
+  desc 'Run rspec test in random order'
+  RSpec::Core::RakeTask.new(:spec_random) do |t|
+    t.rspec_opts = '--order random'
+  end
+rescue LoadError
+  puts 'Could not load rspec'
+end


### PR DESCRIPTION
The project has some decorative unit tests. If we run them, they are not
decorative anymore and can help spot regressions.
